### PR TITLE
Add hex logging for commands

### DIFF
--- a/References/GimbalLib/Ronin/DataHandle.cs
+++ b/References/GimbalLib/Ronin/DataHandle.cs
@@ -168,6 +168,8 @@ namespace CMDSender.Gymbal.Ronin
             bool is_ok = false;
             byte[] cmd_key = new byte[2] {0,0};
 
+            Console.WriteLine($"RECV: {data.ByteArrayToHexString()}");
+
             // If it is a response frame, need to check the corresponding send command
             if (cmd_type == 0x20)
             {

--- a/References/GimbalLib/Ronin/RoninComm.cs
+++ b/References/GimbalLib/Ronin/RoninComm.cs
@@ -586,11 +586,12 @@ namespace CMDSender.Gymbal.Ronin
         private bool SendCanFrameMsg(byte cmd_type, byte cmd_set, byte cmd_id, byte[] cmd_data)
         {
             var cmd = cmdCombine.Combine(cmd_type, cmd_set, cmd_id, cmd_data);
-            if(cmd_type == 0x03)
-            { 
-                dataHandle.AddCommand(cmd); 
+            Console.WriteLine($"SEND: {cmd.ByteArrayToHexString()}");
+            if (cmd_type == 0x03)
+            {
+                dataHandle.AddCommand(cmd);
             }
-            
+
             bool ret = canComm.SendCanFrameMsg(cmd);
             return ret;
         }


### PR DESCRIPTION
## Summary
- print hex bytes for sent commands in `SendCanFrameMsg`
- print received packet hex in `ProcessCMD`

## Testing
- `dotnet build CommanderConsole/CommanderConsole.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685392b846988327a6453ea9bc04e1fc