### PR TITLE
Show hex commands with colored output

### DIFF
--- a/CommanderConsole/Library/References/GimbalLib/Ronin/DataHandle.cs
+++ b/CommanderConsole/Library/References/GimbalLib/Ronin/DataHandle.cs
@@ -165,6 +165,15 @@ namespace CommanderConsole.Gimbal.Ronin
         void ProcessCMD(byte[] data)
         {
             byte cmd_type = (byte)data[3];
+            ConsoleColor color = ConsoleColor.Yellow;
+            if (cmd_type == 0x20)
+            {
+                color = data[14] == 0x00 ? ConsoleColor.Green : ConsoleColor.Red;
+            }
+            Console.ForegroundColor = color;
+            Console.WriteLine($"RX: {data.ByteArrayToHexString()}");
+            Console.ResetColor();
+
             bool is_ok = false;
             byte[] cmd_key = new byte[2] {0,0};
 

--- a/CommanderConsole/Library/References/GimbalLib/Ronin/RoninComm.cs
+++ b/CommanderConsole/Library/References/GimbalLib/Ronin/RoninComm.cs
@@ -587,10 +587,14 @@ namespace CommanderConsole.Gimbal.Ronin
         {
             var cmd = cmdCombine.Combine(cmd_type, cmd_set, cmd_id, cmd_data);
             if(cmd_type == 0x03)
-            { 
-                dataHandle.AddCommand(cmd); 
+            {
+                dataHandle.AddCommand(cmd);
             }
-            
+
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"TX: {cmd.ByteArrayToHexString()}");
+            Console.ResetColor();
+
             bool ret = canComm.SendCanFrameMsg(cmd);
             return ret;
         }

--- a/References/GimbalLib/Ronin/DataHandle.cs
+++ b/References/GimbalLib/Ronin/DataHandle.cs
@@ -165,6 +165,15 @@ namespace CMDSender.Gymbal.Ronin
         void ProcessCMD(byte[] data)
         {
             byte cmd_type = (byte)data[3];
+            ConsoleColor color = ConsoleColor.Yellow;
+            if (cmd_type == 0x20)
+            {
+                color = data[14] == 0x00 ? ConsoleColor.Green : ConsoleColor.Red;
+            }
+            Console.ForegroundColor = color;
+            Console.WriteLine($"RX: {data.ByteArrayToHexString()}");
+            Console.ResetColor();
+
             bool is_ok = false;
             byte[] cmd_key = new byte[2] {0,0};
 

--- a/References/GimbalLib/Ronin/RoninComm.cs
+++ b/References/GimbalLib/Ronin/RoninComm.cs
@@ -587,10 +587,14 @@ namespace CMDSender.Gymbal.Ronin
         {
             var cmd = cmdCombine.Combine(cmd_type, cmd_set, cmd_id, cmd_data);
             if(cmd_type == 0x03)
-            { 
-                dataHandle.AddCommand(cmd); 
+            {
+                dataHandle.AddCommand(cmd);
             }
-            
+
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"TX: {cmd.ByteArrayToHexString()}");
+            Console.ResetColor();
+
             bool ret = canComm.SendCanFrameMsg(cmd);
             return ret;
         }


### PR DESCRIPTION
## Summary
- print hex for sent packets
- show hex for received packets
- use colors for console logs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685394837714832785e03502bc311615